### PR TITLE
ProgressReport: hide PGS for days with >6hrs missing data

### DIFF
--- a/src/components/ReportCard/ProgressCalendar.jsx
+++ b/src/components/ReportCard/ProgressCalendar.jsx
@@ -12,6 +12,7 @@ import { tz } from '../../misc/wrappers';
 import queryString from 'query-string'
 import React from 'react';
 import { color } from './helpers';
+import { HOUR } from '../../model';
 
 export const ProgressCalendar = ({ loading, data, previewedDay, selectedDay, hoveredDay, onHoverDay, onSelectDay }) => {
     const margin = {
@@ -72,13 +73,19 @@ export const ProgressCalendar = ({ loading, data, previewedDay, selectedDay, hov
 
                 // Show PGS only if the day contained data.
                 let pgs
-                if(datum && datum.stats && !date.equals(today)) {
+                // TODO: refactor this disgusting mess.
+                if(datum && datum.stats && !date.equals(today) && datum.stats.totalMinutesMissingData < 60*6) {
                     const { PGS } = datum.stats
                     pgs = <g 
                         transform={`translate(65,80)`}
                         >
                         <circle r={40} cx={0} cy={0} fill={color(PGS)} />
                         <text textAnchor="middle" class={styles.pgsLabel} dy=".3em">{PGS.toFixed(0)}</text>
+                    </g>
+                } else if(date.ordinal < today.ordinal && (!datum || datum.stats.totalMinutesMissingData > 60*3)) {
+                    pgs = <g transform={`translate(65,80)`}>
+                        <circle r={40} cx={0} cy={0} fill={'#8080802e'} />
+                        <text textAnchor="middle" class={styles.pgsLabel} dy=".3em"></text>
                     </g>
                 } else {
                     pgs = <g transform={`translate(65,80)`}>


### PR DESCRIPTION
This hides the PGS for days with >6hrs missing data. It might be a good idea to adjust the PGS monthly statistic to ignore these days too, for consistency.

6hrs was chosen as it represents 25% of the day. The PGS algorithm will interpolate missing data automatically, using a linear curve. 6hrs is enough time to have 2x drastic swings in glucose with two insulin corrections (ie. up to 22mmol and down to 3mmol, corrections 3hrs apart), so it seems it would be better to lower this threshold as to avoid an erroneous PGS. This would make sense if we were using the PGS as a statistical measure, and we cared about its exact value. In this case however, we're using it more as a visual guide, so long as it's correctly stating whether a day was "easy", "medium" or "hard" difficulty (green, orange, red), then we are fine. 3/4 of a day's data is enough to determine this.

## Screenshots.
Two days with 6+ hours missing.

<img width="1605" alt="Screen Shot 2020-10-26 at 12 13 52 pm" src="https://user-images.githubusercontent.com/584141/97127282-ec267f80-1784-11eb-9e16-cab8f7ac09d2.png">

<img width="1615" alt="Screen Shot 2020-10-26 at 12 13 37 pm" src="https://user-images.githubusercontent.com/584141/97127275-e761cb80-1784-11eb-97d2-0e6d32792813.png">

Day with some missing data but falls below threshold.

<img width="1624" alt="Screen Shot 2020-10-26 at 12 14 12 pm" src="https://user-images.githubusercontent.com/584141/97127301-fb0d3200-1784-11eb-931a-b6ef2f764e97.png">
